### PR TITLE
Add time period filtering to photography insights statistics

### DIFF
--- a/src-tauri/src/commands/stats_commands.rs
+++ b/src-tauri/src/commands/stats_commands.rs
@@ -2,10 +2,12 @@
 //!
 //! Provides commands for retrieving photography insights and statistics.
 //! Uses job queue for background calculation and caching for fast access.
+//! Supports time period filtering: all, weekly, monthly, yearly.
 
 use crate::app_state::AppState;
 use crate::domain_service::job_queue::handlers::insights;
 use crate::entity::job_queue::{Job, JobType, JobUnit, QueuedJob};
+use crate::repository::meta_db::sqlite::stats::TimePeriod;
 use crate::repository::meta_db::sqlite::SQLite;
 use serde::Serialize;
 use std::sync::Arc;
@@ -22,36 +24,53 @@ pub struct InsightsCacheStatus {
 ///
 /// Returns cached insights if available, null otherwise.
 /// Use queue_insights_refresh to trigger recalculation.
+///
+/// # Arguments
+/// * `period` - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
 #[tauri::command]
 pub async fn get_cached_insights(
     state: tauri::State<'_, AppState>,
+    period: Option<String>,
 ) -> Result<Option<String>, String> {
-    log::info!(target: "stats", "get_cached_insights; status=checking");
+    let time_period = period
+        .map(|p| TimePeriod::from_str(&p))
+        .unwrap_or(TimePeriod::All);
 
-    match insights::read_cached_insights(&state.config) {
+    log::info!(target: "stats", "get_cached_insights; status=checking; period={}", time_period.as_str());
+
+    match insights::read_cached_insights(&state.config, time_period) {
         Some(cached) => {
-            log::info!(target: "stats", "get_cached_insights; status=found");
+            log::info!(target: "stats", "get_cached_insights; status=found; period={}", time_period.as_str());
             let json = serde_json::to_string(&cached)
                 .map_err(|e| format!("Serialization error: {}", e))?;
             Ok(Some(json))
         }
         None => {
-            log::info!(target: "stats", "get_cached_insights; status=not_found");
+            log::info!(target: "stats", "get_cached_insights; status=not_found; period={}", time_period.as_str());
             Ok(None)
         }
     }
 }
 
 /// Get cache status (whether cache exists and how old it is).
+///
+/// # Arguments
+/// * `period` - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
 #[tauri::command]
 pub async fn get_insights_cache_status(
     state: tauri::State<'_, AppState>,
+    period: Option<String>,
 ) -> Result<InsightsCacheStatus, String> {
-    log::info!(target: "stats", "get_insights_cache_status; status=checking");
+    let time_period = period
+        .map(|p| TimePeriod::from_str(&p))
+        .unwrap_or(TimePeriod::All);
 
-    match insights::get_cache_metadata(&state.config) {
+    log::info!(target: "stats", "get_insights_cache_status; status=checking; period={}", time_period.as_str());
+
+    match insights::get_cache_metadata(&state.config, time_period) {
         Some(metadata) => {
-            log::info!(target: "stats", "get_insights_cache_status; available=true; age_secs={}", metadata.age_secs);
+            log::info!(target: "stats", "get_insights_cache_status; available=true; age_secs={}; period={}",
+                metadata.age_secs, time_period.as_str());
             Ok(InsightsCacheStatus {
                 available: true,
                 age_secs: Some(metadata.age_secs),
@@ -59,7 +78,7 @@ pub async fn get_insights_cache_status(
             })
         }
         None => {
-            log::info!(target: "stats", "get_insights_cache_status; available=false");
+            log::info!(target: "stats", "get_insights_cache_status; available=false; period={}", time_period.as_str());
             Ok(InsightsCacheStatus {
                 available: false,
                 age_secs: None,
@@ -72,12 +91,20 @@ pub async fn get_insights_cache_status(
 /// Queue insights calculation job.
 ///
 /// Returns the job unit ID for tracking progress.
+///
+/// # Arguments
+/// * `period` - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
 #[tauri::command]
 pub async fn queue_insights_refresh(
     state: tauri::State<'_, AppState>,
     app_handle: tauri::AppHandle,
+    period: Option<String>,
 ) -> Result<String, String> {
-    log::info!(target: "stats", "queue_insights_refresh; status=queueing");
+    let time_period = period
+        .map(|p| TimePeriod::from_str(&p))
+        .unwrap_or(TimePeriod::All);
+
+    log::info!(target: "stats", "queue_insights_refresh; status=queueing; period={}", time_period.as_str());
 
     let sqlite = SQLite::new(state.config.import_to.clone());
 
@@ -89,14 +116,19 @@ pub async fn queue_insights_refresh(
     // Save job unit
     sqlite.create_job_unit(&job_unit)?;
 
-    // Create the job (empty target - insights doesn't need file list)
-    let job = Job::new(job_unit_id.clone(), JobType::InsightsCalculation, vec![]);
+    // Create the job with period as target (to pass period info to job handler)
+    let job = Job::new(
+        job_unit_id.clone(),
+        JobType::InsightsCalculation,
+        vec![time_period.as_str().to_string()],
+    );
     let queued_job = QueuedJob::new(job_unit_id.clone(), job);
 
     // Save job to queue
     sqlite.create_job(&queued_job)?;
 
-    log::info!(target: "stats", "queue_insights_refresh; status=queued; job_unit_id={}", job_unit_id);
+    log::info!(target: "stats", "queue_insights_refresh; status=queued; job_unit_id={}; period={}",
+        job_unit_id, time_period.as_str());
 
     // Trigger job processing
     let db_arc = Arc::new(sqlite);
@@ -109,17 +141,29 @@ pub async fn queue_insights_refresh(
 ///
 /// This is a fallback for when cache is not available.
 /// Prefer using get_cached_insights + queue_insights_refresh.
+///
+/// # Arguments
+/// * `period` - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
 #[tauri::command]
 pub async fn get_photography_insights(
     state: tauri::State<'_, AppState>,
+    period: Option<String>,
 ) -> Result<String, String> {
-    log::info!(target: "stats", "get_photography_insights; status=starting");
+    let time_period = period
+        .map(|p| TimePeriod::from_str(&p))
+        .unwrap_or(TimePeriod::All);
+
+    log::info!(target: "stats", "get_photography_insights; status=starting; period={}", time_period.as_str());
 
     let sqlite = SQLite::new(state.config.import_to.clone());
 
-    let insights = crate::repository::meta_db::sqlite::stats::get_all_insights(&sqlite, &state.config)?;
+    let insights = crate::repository::meta_db::sqlite::stats::get_all_insights(
+        &sqlite,
+        &state.config,
+        time_period,
+    )?;
 
-    log::info!(target: "stats", "get_photography_insights; status=complete");
+    log::info!(target: "stats", "get_photography_insights; status=complete; period={}", time_period.as_str());
 
     serde_json::to_string(&insights).map_err(|e| format!("Serialization error: {}", e))
 }

--- a/src-tauri/src/domain_service/job_queue/handlers/insights.rs
+++ b/src-tauri/src/domain_service/job_queue/handlers/insights.rs
@@ -1,10 +1,12 @@
 //! Insights calculation job handler.
 //!
 //! Calculates photography insights statistics and saves to cache.
+//! Supports time period filtering with separate cache files per period.
 
 use crate::entity::job_queue::QueuedJob;
-use crate::repository::meta_db::sqlite::stats;
+use crate::repository::meta_db::sqlite::stats::{self, TimePeriod};
 use crate::repository::meta_db::sqlite::SQLite;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 use tauri::{Emitter, Manager};
@@ -16,21 +18,31 @@ pub(crate) fn process_insights_job(
     db: &SQLite,
 ) -> Result<(), String> {
     let job_id = job.id.unwrap_or(0);
-    log::info!(target: "job_queue", "insights_job; job_id={}; status=starting", job_id);
+
+    // Extract period from job targets (first element is period string)
+    let period = job
+        .targets
+        .first()
+        .map(|s| TimePeriod::from_str(s))
+        .unwrap_or(TimePeriod::All);
+
+    log::info!(target: "job_queue", "insights_job; job_id={}; status=starting; period={}",
+        job_id, period.as_str());
 
     let state = app_handle.state::<crate::AppState>();
     let config = &state.config;
 
     // Calculate insights
-    log::info!(target: "job_queue", "insights_job; job_id={}; status=calculating", job_id);
-    let insights = stats::get_all_insights(db, config)?;
+    log::info!(target: "job_queue", "insights_job; job_id={}; status=calculating; period={}",
+        job_id, period.as_str());
+    let insights = stats::get_all_insights(db, config, period)?;
 
     // Serialize to JSON
     let json = serde_json::to_string_pretty(&insights)
         .map_err(|e| format!("Failed to serialize insights: {}", e))?;
 
-    // Get cache directory
-    let cache_path = get_insights_cache_path(config);
+    // Get cache directory (period-specific)
+    let cache_path = get_insights_cache_path(config, period);
 
     // Ensure cache directory exists
     if let Some(parent) = Path::new(&cache_path).parent() {
@@ -44,57 +56,74 @@ pub(crate) fn process_insights_job(
     fs::write(&cache_path, &json)
         .map_err(|e| format!("Failed to write insights cache: {}", e))?;
 
-    log::info!(target: "job_queue", "insights_job; job_id={}; status=complete; cache_path={}", job_id, cache_path);
+    log::info!(target: "job_queue", "insights_job; job_id={}; status=complete; cache_path={}; period={}",
+        job_id, cache_path, period.as_str());
 
-    // Emit event to notify frontend
-    if let Err(e) = app_handle.emit("insights_updated", &cache_path) {
+    // Emit event to notify frontend (include period info)
+    let event_payload = InsightsUpdatedPayload {
+        path: cache_path,
+        period: period.as_str().to_string(),
+    };
+    if let Err(e) = app_handle.emit("insights_updated", &event_payload) {
         log::error!(target: "job_queue", "insights_job; job_id={}; emit_error={}", job_id, e);
     }
 
     Ok(())
 }
 
-/// Get the cache file path for insights
-pub fn get_insights_cache_path(_config: &crate::entity::config::Config) -> String {
+/// Payload for insights_updated event
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InsightsUpdatedPayload {
+    pub path: String,
+    pub period: String,
+}
+
+/// Get the cache file path for insights (period-specific)
+pub fn get_insights_cache_path(
+    _config: &crate::entity::config::Config,
+    period: TimePeriod,
+) -> String {
     let cache_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("photoclove")
         .join("cache");
 
-    cache_dir
-        .join("insights.json")
-        .to_string_lossy()
-        .to_string()
+    let filename = format!("insights_{}.json", period.as_str());
+    cache_dir.join(filename).to_string_lossy().to_string()
 }
 
 /// Read cached insights if available
-pub fn read_cached_insights(config: &crate::entity::config::Config) -> Option<stats::PhotographyInsights> {
-    let cache_path = get_insights_cache_path(config);
+pub fn read_cached_insights(
+    config: &crate::entity::config::Config,
+    period: TimePeriod,
+) -> Option<stats::PhotographyInsights> {
+    let cache_path = get_insights_cache_path(config, period);
 
     if !Path::new(&cache_path).exists() {
         return None;
     }
 
     match fs::read_to_string(&cache_path) {
-        Ok(json) => {
-            match serde_json::from_str(&json) {
-                Ok(insights) => Some(insights),
-                Err(e) => {
-                    log::warn!(target: "stats", "read_cached_insights; parse_error={}", e);
-                    None
-                }
+        Ok(json) => match serde_json::from_str(&json) {
+            Ok(insights) => Some(insights),
+            Err(e) => {
+                log::warn!(target: "stats", "read_cached_insights; parse_error={}; period={}", e, period.as_str());
+                None
             }
-        }
+        },
         Err(e) => {
-            log::warn!(target: "stats", "read_cached_insights; read_error={}", e);
+            log::warn!(target: "stats", "read_cached_insights; read_error={}; period={}", e, period.as_str());
             None
         }
     }
 }
 
 /// Get cache file metadata (for checking age)
-pub fn get_cache_metadata(config: &crate::entity::config::Config) -> Option<CacheMetadata> {
-    let cache_path = get_insights_cache_path(config);
+pub fn get_cache_metadata(
+    config: &crate::entity::config::Config,
+    period: TimePeriod,
+) -> Option<CacheMetadata> {
+    let cache_path = get_insights_cache_path(config, period);
 
     if !Path::new(&cache_path).exists() {
         return None;
@@ -106,6 +135,7 @@ pub fn get_cache_metadata(config: &crate::entity::config::Config) -> Option<Cach
             let age_secs = modified.elapsed().ok()?.as_secs();
             Some(CacheMetadata {
                 path: cache_path,
+                period: period.as_str().to_string(),
                 age_secs,
                 size_bytes: metadata.len(),
             })
@@ -118,6 +148,7 @@ pub fn get_cache_metadata(config: &crate::entity::config::Config) -> Option<Cach
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CacheMetadata {
     pub path: String,
+    pub period: String,
     pub age_secs: u64,
     pub size_bytes: u64,
 }

--- a/src-tauri/src/repository/meta_db/sqlite/stats.rs
+++ b/src-tauri/src/repository/meta_db/sqlite/stats.rs
@@ -6,16 +6,85 @@
 //! - Equipment usage (cameras, lenses)
 //! - Organization metrics (total photos, tags, albums)
 //! - Storage usage
+//!
+//! Supports time period filtering: all, weekly, monthly, yearly.
 
 use crate::entity::config::Config;
 use crate::repository::meta_db::sqlite::SQLite;
+use chrono::{Duration, Local, NaiveDate};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
+/// Time period for filtering statistics
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TimePeriod {
+    /// All time (no filtering)
+    All,
+    /// Last 7 days
+    Weekly,
+    /// Last 30 days
+    Monthly,
+    /// Last 365 days
+    Yearly,
+}
+
+impl Default for TimePeriod {
+    fn default() -> Self {
+        TimePeriod::All
+    }
+}
+
+impl TimePeriod {
+    /// Get the start date for this period (None means no filtering)
+    pub fn start_date(&self) -> Option<NaiveDate> {
+        let today = Local::now().date_naive();
+        match self {
+            TimePeriod::All => None,
+            TimePeriod::Weekly => Some(today - Duration::days(7)),
+            TimePeriod::Monthly => Some(today - Duration::days(30)),
+            TimePeriod::Yearly => Some(today - Duration::days(365)),
+        }
+    }
+
+    /// Get SQL date condition for this period
+    pub fn date_condition(&self) -> String {
+        match self.start_date() {
+            Some(date) => format!(
+                " AND date(COALESCE(exif_date_time_original, photo_date)) >= '{}'",
+                date.format("%Y-%m-%d")
+            ),
+            None => String::new(),
+        }
+    }
+
+    /// Parse from string
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "weekly" => TimePeriod::Weekly,
+            "monthly" => TimePeriod::Monthly,
+            "yearly" => TimePeriod::Yearly,
+            _ => TimePeriod::All,
+        }
+    }
+
+    /// Convert to string
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TimePeriod::All => "all",
+            TimePeriod::Weekly => "weekly",
+            TimePeriod::Monthly => "monthly",
+            TimePeriod::Yearly => "yearly",
+        }
+    }
+}
+
 /// Complete photography insights data
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PhotographyInsights {
+    /// Time period for this statistics
+    pub period: TimePeriod,
     pub shooting_time: ShootingTimeStats,
     pub camera_settings: CameraSettingsStats,
     pub equipment: EquipmentStats,
@@ -91,19 +160,25 @@ pub struct StorageStats {
     pub face_thumbnail_size_bytes: u64,
 }
 
-/// Get all photography insights
-pub fn get_all_insights(sqlite: &SQLite, config: &Config) -> Result<PhotographyInsights, String> {
-    log::info!(target: "stats", "get_all_insights; status=starting");
+/// Get all photography insights for a specific time period
+pub fn get_all_insights(
+    sqlite: &SQLite,
+    config: &Config,
+    period: TimePeriod,
+) -> Result<PhotographyInsights, String> {
+    log::info!(target: "stats", "get_all_insights; status=starting; period={}", period.as_str());
 
-    let shooting_time = get_shooting_time_stats(sqlite)?;
-    let camera_settings = get_camera_settings_stats(sqlite)?;
-    let equipment = get_equipment_stats(sqlite)?;
-    let organization = get_organization_stats(sqlite)?;
+    let shooting_time = get_shooting_time_stats(sqlite, period)?;
+    let camera_settings = get_camera_settings_stats(sqlite, period)?;
+    let equipment = get_equipment_stats(sqlite, period)?;
+    let organization = get_organization_stats(sqlite, period)?;
+    // Storage stats are not affected by time period (always shows current usage)
     let storage = get_storage_stats(config)?;
 
-    log::info!(target: "stats", "get_all_insights; status=complete");
+    log::info!(target: "stats", "get_all_insights; status=complete; period={}", period.as_str());
 
     Ok(PhotographyInsights {
+        period,
         shooting_time,
         camera_settings,
         equipment,
@@ -113,23 +188,28 @@ pub fn get_all_insights(sqlite: &SQLite, config: &Config) -> Result<PhotographyI
 }
 
 /// Get shooting time statistics (hour of day, day of week)
-fn get_shooting_time_stats(sqlite: &SQLite) -> Result<ShootingTimeStats, String> {
+fn get_shooting_time_stats(sqlite: &SQLite, period: TimePeriod) -> Result<ShootingTimeStats, String> {
     let conn = sqlite
         .get_connection()
         .map_err(|e| format!("Failed to connect: {}", e))?;
 
+    let date_filter = period.date_condition();
+
     // Hour distribution from exif_date_time_original
+    let hour_query = format!(
+        "SELECT
+            CAST(SUBSTR(COALESCE(exif_date_time_original, photo_date), 12, 2) AS INTEGER) as hour,
+            COUNT(*) as count
+         FROM photo_metadata
+         WHERE (exif_date_time_original IS NOT NULL OR photo_date IS NOT NULL)
+           AND (delete_flg = 0 OR delete_flg IS NULL){}
+         GROUP BY hour
+         ORDER BY hour",
+        date_filter
+    );
+
     let mut hour_stmt = conn
-        .prepare(
-            "SELECT
-                CAST(SUBSTR(COALESCE(exif_date_time_original, photo_date), 12, 2) AS INTEGER) as hour,
-                COUNT(*) as count
-             FROM photo_metadata
-             WHERE (exif_date_time_original IS NOT NULL OR photo_date IS NOT NULL)
-               AND (delete_flg = 0 OR delete_flg IS NULL)
-             GROUP BY hour
-             ORDER BY hour",
-        )
+        .prepare(&hour_query)
         .map_err(|e| format!("Failed to prepare hour query: {}", e))?;
 
     let hour_distribution: Vec<HourCount> = hour_stmt
@@ -144,17 +224,20 @@ fn get_shooting_time_stats(sqlite: &SQLite) -> Result<ShootingTimeStats, String>
         .collect();
 
     // Day of week distribution
+    let day_query = format!(
+        "SELECT
+            CAST(strftime('%w', date(COALESCE(exif_date_time_original, photo_date))) AS INTEGER) as day,
+            COUNT(*) as count
+         FROM photo_metadata
+         WHERE (exif_date_time_original IS NOT NULL OR photo_date IS NOT NULL)
+           AND (delete_flg = 0 OR delete_flg IS NULL){}
+         GROUP BY day
+         ORDER BY day",
+        date_filter
+    );
+
     let mut day_stmt = conn
-        .prepare(
-            "SELECT
-                CAST(strftime('%w', date(COALESCE(exif_date_time_original, photo_date))) AS INTEGER) as day,
-                COUNT(*) as count
-             FROM photo_metadata
-             WHERE (exif_date_time_original IS NOT NULL OR photo_date IS NOT NULL)
-               AND (delete_flg = 0 OR delete_flg IS NULL)
-             GROUP BY day
-             ORDER BY day",
-        )
+        .prepare(&day_query)
         .map_err(|e| format!("Failed to prepare day query: {}", e))?;
 
     let day_names = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
@@ -179,45 +262,59 @@ fn get_shooting_time_stats(sqlite: &SQLite) -> Result<ShootingTimeStats, String>
 }
 
 /// Get camera settings distribution
-fn get_camera_settings_stats(sqlite: &SQLite) -> Result<CameraSettingsStats, String> {
+fn get_camera_settings_stats(sqlite: &SQLite, period: TimePeriod) -> Result<CameraSettingsStats, String> {
     let conn = sqlite
         .get_connection()
         .map_err(|e| format!("Failed to connect: {}", e))?;
 
+    let date_filter = period.date_condition();
+
     // ISO distribution
     let iso_distribution = query_setting_distribution(
         &conn,
-        "SELECT exif_iso, COUNT(*) FROM photo_metadata
-         WHERE exif_iso IS NOT NULL AND exif_iso != ''
-           AND (delete_flg = 0 OR delete_flg IS NULL)
-         GROUP BY exif_iso ORDER BY CAST(exif_iso AS INTEGER) LIMIT 20",
+        &format!(
+            "SELECT exif_iso, COUNT(*) FROM photo_metadata
+             WHERE exif_iso IS NOT NULL AND exif_iso != ''
+               AND (delete_flg = 0 OR delete_flg IS NULL){}
+             GROUP BY exif_iso ORDER BY CAST(exif_iso AS INTEGER) LIMIT 20",
+            date_filter
+        ),
     )?;
 
     // Aperture distribution
     let aperture_distribution = query_setting_distribution(
         &conn,
-        "SELECT exif_fnumber, COUNT(*) FROM photo_metadata
-         WHERE exif_fnumber IS NOT NULL AND exif_fnumber != ''
-           AND (delete_flg = 0 OR delete_flg IS NULL)
-         GROUP BY exif_fnumber ORDER BY CAST(exif_fnumber AS REAL) LIMIT 20",
+        &format!(
+            "SELECT exif_fnumber, COUNT(*) FROM photo_metadata
+             WHERE exif_fnumber IS NOT NULL AND exif_fnumber != ''
+               AND (delete_flg = 0 OR delete_flg IS NULL){}
+             GROUP BY exif_fnumber ORDER BY CAST(exif_fnumber AS REAL) LIMIT 20",
+            date_filter
+        ),
     )?;
 
     // Shutter speed distribution
     let shutter_speed_distribution = query_setting_distribution(
         &conn,
-        "SELECT exif_exposure_time, COUNT(*) as count FROM photo_metadata
-         WHERE exif_exposure_time IS NOT NULL AND exif_exposure_time != ''
-           AND (delete_flg = 0 OR delete_flg IS NULL)
-         GROUP BY exif_exposure_time ORDER BY count DESC LIMIT 20",
+        &format!(
+            "SELECT exif_exposure_time, COUNT(*) as count FROM photo_metadata
+             WHERE exif_exposure_time IS NOT NULL AND exif_exposure_time != ''
+               AND (delete_flg = 0 OR delete_flg IS NULL){}
+             GROUP BY exif_exposure_time ORDER BY count DESC LIMIT 20",
+            date_filter
+        ),
     )?;
 
     // Focal length distribution
     let focal_length_distribution = query_setting_distribution(
         &conn,
-        "SELECT exif_focal_length, COUNT(*) FROM photo_metadata
-         WHERE exif_focal_length IS NOT NULL AND exif_focal_length != ''
-           AND (delete_flg = 0 OR delete_flg IS NULL)
-         GROUP BY exif_focal_length ORDER BY CAST(exif_focal_length AS REAL) LIMIT 20",
+        &format!(
+            "SELECT exif_focal_length, COUNT(*) FROM photo_metadata
+             WHERE exif_focal_length IS NOT NULL AND exif_focal_length != ''
+               AND (delete_flg = 0 OR delete_flg IS NULL){}
+             GROUP BY exif_focal_length ORDER BY CAST(exif_focal_length AS REAL) LIMIT 20",
+            date_filter
+        ),
     )?;
 
     Ok(CameraSettingsStats {
@@ -252,22 +349,27 @@ fn query_setting_distribution(
 }
 
 /// Get equipment statistics (cameras, lenses)
-fn get_equipment_stats(sqlite: &SQLite) -> Result<EquipmentStats, String> {
+fn get_equipment_stats(sqlite: &SQLite, period: TimePeriod) -> Result<EquipmentStats, String> {
     let conn = sqlite
         .get_connection()
         .map_err(|e| format!("Failed to connect: {}", e))?;
 
+    let date_filter = period.date_condition();
+
     // Camera ranking
+    let camera_query = format!(
+        "SELECT exif_make, exif_model, COUNT(*) as count
+         FROM photo_metadata
+         WHERE exif_model IS NOT NULL AND exif_model != ''
+           AND (delete_flg = 0 OR delete_flg IS NULL){}
+         GROUP BY exif_make, exif_model
+         ORDER BY count DESC
+         LIMIT 10",
+        date_filter
+    );
+
     let mut camera_stmt = conn
-        .prepare(
-            "SELECT exif_make, exif_model, COUNT(*) as count
-             FROM photo_metadata
-             WHERE exif_model IS NOT NULL AND exif_model != ''
-               AND (delete_flg = 0 OR delete_flg IS NULL)
-             GROUP BY exif_make, exif_model
-             ORDER BY count DESC
-             LIMIT 10",
-        )
+        .prepare(&camera_query)
         .map_err(|e| format!("Failed to prepare camera query: {}", e))?;
 
     let cameras: Vec<EquipmentCount> = camera_stmt
@@ -283,16 +385,19 @@ fn get_equipment_stats(sqlite: &SQLite) -> Result<EquipmentStats, String> {
         .collect();
 
     // Lens ranking
+    let lens_query = format!(
+        "SELECT exif_lens_make, exif_lens_model, COUNT(*) as count
+         FROM photo_metadata
+         WHERE exif_lens_model IS NOT NULL AND exif_lens_model != ''
+           AND (delete_flg = 0 OR delete_flg IS NULL){}
+         GROUP BY exif_lens_make, exif_lens_model
+         ORDER BY count DESC
+         LIMIT 10",
+        date_filter
+    );
+
     let mut lens_stmt = conn
-        .prepare(
-            "SELECT exif_lens_make, exif_lens_model, COUNT(*) as count
-             FROM photo_metadata
-             WHERE exif_lens_model IS NOT NULL AND exif_lens_model != ''
-               AND (delete_flg = 0 OR delete_flg IS NULL)
-             GROUP BY exif_lens_make, exif_lens_model
-             ORDER BY count DESC
-             LIMIT 10",
-        )
+        .prepare(&lens_query)
         .map_err(|e| format!("Failed to prepare lens query: {}", e))?;
 
     let lenses: Vec<EquipmentCount> = lens_stmt
@@ -311,28 +416,34 @@ fn get_equipment_stats(sqlite: &SQLite) -> Result<EquipmentStats, String> {
 }
 
 /// Get organization metrics
-fn get_organization_stats(sqlite: &SQLite) -> Result<OrganizationStats, String> {
+fn get_organization_stats(sqlite: &SQLite, period: TimePeriod) -> Result<OrganizationStats, String> {
     let conn = sqlite
         .get_connection()
         .map_err(|e| format!("Failed to connect: {}", e))?;
 
+    let date_filter = period.date_condition();
+
+    let total_photos_query = format!(
+        "SELECT COUNT(*) FROM photo_metadata
+         WHERE (delete_flg = 0 OR delete_flg IS NULL){}",
+        date_filter
+    );
+
     let total_photos: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM photo_metadata WHERE delete_flg = 0 OR delete_flg IS NULL",
-            [],
-            |row| row.get(0),
-        )
+        .query_row(&total_photos_query, [], |row| row.get(0))
         .unwrap_or(0);
+
+    let starred_photos_query = format!(
+        "SELECT COUNT(*) FROM photo_metadata
+         WHERE star > 0 AND (delete_flg = 0 OR delete_flg IS NULL){}",
+        date_filter
+    );
 
     let starred_photos: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM photo_metadata
-             WHERE star > 0 AND (delete_flg = 0 OR delete_flg IS NULL)",
-            [],
-            |row| row.get(0),
-        )
+        .query_row(&starred_photos_query, [], |row| row.get(0))
         .unwrap_or(0);
 
+    // Tags and albums count are not filtered by date (they are collections, not photos)
     let total_tags: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM photo_collections WHERE type = 'tag'",
@@ -349,26 +460,39 @@ fn get_organization_stats(sqlite: &SQLite) -> Result<OrganizationStats, String> 
         )
         .unwrap_or(0);
 
-    let photos_with_tags: i64 = conn
-        .query_row(
-            "SELECT COUNT(DISTINCT pci.photo_path)
-             FROM photo_collection_items pci
-             JOIN photo_collections pc ON pc.id = pci.collection_id
-             WHERE pc.type = 'tag'",
-            [],
-            |row| row.get(0),
+    // Photos with tags/albums are filtered by the photo's date
+    let photos_with_tags_query = format!(
+        "SELECT COUNT(DISTINCT pci.photo_path)
+         FROM photo_collection_items pci
+         JOIN photo_collections pc ON pc.id = pci.collection_id
+         JOIN photo_metadata pm ON pm.absolute_path = pci.photo_path
+         WHERE pc.type = 'tag'
+           AND (pm.delete_flg = 0 OR pm.delete_flg IS NULL){}",
+        date_filter.replace(
+            "COALESCE(exif_date_time_original, photo_date)",
+            "COALESCE(pm.exif_date_time_original, pm.photo_date)"
         )
+    );
+
+    let photos_with_tags: i64 = conn
+        .query_row(&photos_with_tags_query, [], |row| row.get(0))
         .unwrap_or(0);
 
-    let photos_in_albums: i64 = conn
-        .query_row(
-            "SELECT COUNT(DISTINCT pci.photo_path)
-             FROM photo_collection_items pci
-             JOIN photo_collections pc ON pc.id = pci.collection_id
-             WHERE pc.type = 'album'",
-            [],
-            |row| row.get(0),
+    let photos_in_albums_query = format!(
+        "SELECT COUNT(DISTINCT pci.photo_path)
+         FROM photo_collection_items pci
+         JOIN photo_collections pc ON pc.id = pci.collection_id
+         JOIN photo_metadata pm ON pm.absolute_path = pci.photo_path
+         WHERE pc.type = 'album'
+           AND (pm.delete_flg = 0 OR pm.delete_flg IS NULL){}",
+        date_filter.replace(
+            "COALESCE(exif_date_time_original, photo_date)",
+            "COALESCE(pm.exif_date_time_original, pm.photo_date)"
         )
+    );
+
+    let photos_in_albums: i64 = conn
+        .query_row(&photos_in_albums_query, [], |row| row.get(0))
         .unwrap_or(0);
 
     Ok(OrganizationStats {

--- a/src/App/InsightsModal.jsx
+++ b/src/App/InsightsModal.jsx
@@ -15,7 +15,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useTranslation } from 'react-i18next';
 import BaseModal, { ModalLoading, ModalError } from "../components/BaseModal.jsx";
 import { logger } from "../services/LoggerService.js";
-import InsightsService from "../services/InsightsService.js";
+import InsightsService, { TIME_PERIODS } from "../services/InsightsService.js";
 import ShootingTimeSection from "./Insights/ShootingTimeSection.jsx";
 import CameraSettingsSection from "./Insights/CameraSettingsSection.jsx";
 import EquipmentSection from "./Insights/EquipmentSection.jsx";
@@ -33,58 +33,76 @@ function InsightsModal({ onClose }) {
     const [activeSection, setActiveSection] = useState('shooting_time');
     const [cacheAge, setCacheAge] = useState(null);
     const [showShareDialog, setShowShareDialog] = useState(false);
+    const [selectedPeriod, setSelectedPeriod] = useState(TIME_PERIODS.ALL);
+
+    // Period options for the selector
+    const periodOptions = [
+        { value: TIME_PERIODS.ALL, label: t('insights:periods.all', 'All Time') },
+        { value: TIME_PERIODS.WEEKLY, label: t('insights:periods.weekly', 'Weekly') },
+        { value: TIME_PERIODS.MONTHLY, label: t('insights:periods.monthly', 'Monthly') },
+        { value: TIME_PERIODS.YEARLY, label: t('insights:periods.yearly', 'Yearly') },
+    ];
 
     // Load insights from cache or trigger refresh
-    const loadInsights = useCallback(async () => {
+    const loadInsights = useCallback(async (period = selectedPeriod) => {
         try {
             setLoading(true);
             setError(null);
 
             // First, try to get cached insights
-            const cached = await InsightsService.getCachedInsights();
+            const cached = await InsightsService.getCachedInsights(period);
 
             if (cached) {
                 setInsights(cached);
                 // Get cache age
-                const status = await InsightsService.getCacheStatus();
+                const status = await InsightsService.getCacheStatus(period);
                 setCacheAge(status.age_secs);
                 logger.info('InsightsModal', 'load_from_cache', 'Loaded from cache', {
-                    age_secs: status.age_secs
+                    age_secs: status.age_secs,
+                    period
                 });
             } else {
                 // No cache, trigger refresh
-                logger.info('InsightsModal', 'no_cache', 'No cache found, triggering refresh');
-                await triggerRefresh();
+                logger.info('InsightsModal', 'no_cache', 'No cache found, triggering refresh', { period });
+                await triggerRefresh(period);
             }
         } catch (err) {
             const errorMsg = typeof err === 'string' ? err : (err.message || JSON.stringify(err) || 'Failed to load insights');
             setError(errorMsg);
-            logger.error('InsightsModal', 'load_error', 'Failed to load insights', { error: err });
+            logger.error('InsightsModal', 'load_error', 'Failed to load insights', { error: err, period });
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [selectedPeriod]);
 
     // Trigger background refresh
-    const triggerRefresh = async () => {
+    const triggerRefresh = async (period = selectedPeriod) => {
         try {
             setRefreshing(true);
             setError(null);
-            logger.info('InsightsModal', 'refresh_start', 'Queueing refresh job');
-            await InsightsService.queueRefresh();
+            logger.info('InsightsModal', 'refresh_start', 'Queueing refresh job', { period });
+            await InsightsService.queueRefresh(period);
             // Job will emit 'insights_updated' event when done
         } catch (err) {
             const errorMsg = typeof err === 'string' ? err : (err.message || 'Failed to queue refresh');
             setError(errorMsg);
             setRefreshing(false);
-            logger.error('InsightsModal', 'refresh_error', 'Failed to queue refresh', { error: err });
+            logger.error('InsightsModal', 'refresh_error', 'Failed to queue refresh', { error: err, period });
         }
+    };
+
+    // Handle period change
+    const handlePeriodChange = async (newPeriod) => {
+        if (newPeriod === selectedPeriod || refreshing) return;
+        logger.info('InsightsModal', 'period_change', 'Changing period', { from: selectedPeriod, to: newPeriod });
+        setSelectedPeriod(newPeriod);
+        await loadInsights(newPeriod);
     };
 
     // Handle refresh button click
     const handleRefresh = async () => {
         if (refreshing) return;
-        await triggerRefresh();
+        await triggerRefresh(selectedPeriod);
     };
 
     // Listen for insights_updated event
@@ -92,20 +110,28 @@ function InsightsModal({ onClose }) {
         let unlisten;
 
         const setupListener = async () => {
-            unlisten = await InsightsService.onInsightsUpdated(async () => {
-                logger.info('InsightsModal', 'insights_updated', 'Received update event');
-                // Reload from cache
-                try {
-                    const cached = await InsightsService.getCachedInsights();
-                    if (cached) {
-                        setInsights(cached);
-                        setCacheAge(0); // Just updated
+            unlisten = await InsightsService.onInsightsUpdated(async (payload) => {
+                const updatedPeriod = payload?.period || TIME_PERIODS.ALL;
+                logger.info('InsightsModal', 'insights_updated', 'Received update event', {
+                    updatedPeriod,
+                    selectedPeriod
+                });
+
+                // Only update if the period matches
+                if (updatedPeriod === selectedPeriod) {
+                    // Reload from cache
+                    try {
+                        const cached = await InsightsService.getCachedInsights(selectedPeriod);
+                        if (cached) {
+                            setInsights(cached);
+                            setCacheAge(0); // Just updated
+                        }
+                    } catch (err) {
+                        logger.error('InsightsModal', 'reload_error', 'Failed to reload after update', { error: err });
+                    } finally {
+                        setRefreshing(false);
+                        setLoading(false);
                     }
-                } catch (err) {
-                    logger.error('InsightsModal', 'reload_error', 'Failed to reload after update', { error: err });
-                } finally {
-                    setRefreshing(false);
-                    setLoading(false);
                 }
             });
         };
@@ -115,7 +141,7 @@ function InsightsModal({ onClose }) {
         return () => {
             if (unlisten) unlisten();
         };
-    }, []);
+    }, [selectedPeriod]);
 
     // Initial load
     useEffect(() => {
@@ -149,19 +175,40 @@ function InsightsModal({ onClose }) {
         }
     };
 
-    const tabs = (
-        <div className={styles.tabs}>
-            {sections.map(section => (
-                <button
-                    key={section.id}
-                    className={`${styles.tab} ${activeSection === section.id ? styles.active : ''}`}
-                    onClick={() => setActiveSection(section.id)}
-                >
-                    <span className={styles.tabIcon}>{section.icon}</span>
-                    <span className={styles.tabLabel}>{section.label}</span>
-                </button>
-            ))}
+    const periodSelector = (
+        <div className={styles.periodSelector}>
+            <span className={styles.periodLabel}>{t('insights:periods.label', 'Period:')}</span>
+            <div className={styles.periodButtons}>
+                {periodOptions.map(option => (
+                    <button
+                        key={option.value}
+                        className={`${styles.periodBtn} ${selectedPeriod === option.value ? styles.active : ''}`}
+                        onClick={() => handlePeriodChange(option.value)}
+                        disabled={refreshing || loading}
+                    >
+                        {option.label}
+                    </button>
+                ))}
+            </div>
         </div>
+    );
+
+    const tabs = (
+        <>
+            {periodSelector}
+            <div className={styles.tabs}>
+                {sections.map(section => (
+                    <button
+                        key={section.id}
+                        className={`${styles.tab} ${activeSection === section.id ? styles.active : ''}`}
+                        onClick={() => setActiveSection(section.id)}
+                    >
+                        <span className={styles.tabIcon}>{section.icon}</span>
+                        <span className={styles.tabLabel}>{section.label}</span>
+                    </button>
+                ))}
+            </div>
+        </>
     );
 
     const footerContent = (

--- a/src/App/InsightsModal.jsx
+++ b/src/App/InsightsModal.jsx
@@ -269,6 +269,7 @@ function InsightsModal({ onClose }) {
             {showShareDialog && (
                 <ShareStatsDialog
                     insights={insights}
+                    period={selectedPeriod}
                     onClose={() => setShowShareDialog(false)}
                 />
             )}

--- a/src/App/InsightsModal.module.css
+++ b/src/App/InsightsModal.module.css
@@ -1,5 +1,53 @@
 /* InsightsModal Styles */
 
+/* Period Selector */
+.periodSelector {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    background-color: var(--color-bg-elevated);
+    border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.periodLabel {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin-right: var(--space-2);
+}
+
+.periodButtons {
+    display: flex;
+    gap: var(--space-1);
+}
+
+.periodBtn {
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+    transition: all 0.15s ease-out;
+}
+
+.periodBtn:hover {
+    background: var(--color-bg-muted);
+    color: var(--color-text-primary);
+}
+
+.periodBtn.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: white;
+}
+
+.periodBtn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .tabs {
     display: flex;
     gap: var(--space-1);

--- a/src/components/ShareStatsDialog.jsx
+++ b/src/components/ShareStatsDialog.jsx
@@ -15,7 +15,7 @@ import {
 import { logger } from '../services/LoggerService.js';
 import styles from './ShareStatsDialog.module.css';
 
-function ShareStatsDialog({ insights, onClose }) {
+function ShareStatsDialog({ insights, period = 'all', onClose }) {
     const { t } = useTranslation(['common', 'insights']);
     const [shareText, setShareText] = useState('');
     const [imageBlob, setImageBlob] = useState(null);
@@ -26,16 +26,16 @@ function ShareStatsDialog({ insights, onClose }) {
     // Generate share text
     useEffect(() => {
         if (insights) {
-            const text = generateStatsShareText(insights);
+            const text = generateStatsShareText(insights, period);
             setShareText(text);
         }
-    }, [insights]);
+    }, [insights, period]);
 
     // Generate image preview
     useEffect(() => {
         if (insights) {
             setGenerating(true);
-            generateStatsImage(insights)
+            generateStatsImage(insights, { period })
                 .then(blob => {
                     setImageBlob(blob);
                     setImageUrl(URL.createObjectURL(blob));
@@ -52,7 +52,7 @@ function ShareStatsDialog({ insights, onClose }) {
                 URL.revokeObjectURL(imageUrl);
             }
         };
-    }, [insights]);
+    }, [insights, period]);
 
     // Handle copy text
     const handleCopyText = useCallback(async () => {

--- a/src/i18n/locales/de/insights.json
+++ b/src/i18n/locales/de/insights.json
@@ -4,6 +4,13 @@
   "photos": "Fotos",
   "noData": "Keine Daten verfügbar",
   "mostUsed": "Am meisten verwendet",
+  "periods": {
+    "label": "Zeitraum:",
+    "all": "Gesamter Zeitraum",
+    "weekly": "Wöchentlich",
+    "monthly": "Monatlich",
+    "yearly": "Jährlich"
+  },
   "sections": {
     "shootingTime": "Aufnahmezeit",
     "cameraSettings": "Kameraeinstellungen",

--- a/src/i18n/locales/en/insights.json
+++ b/src/i18n/locales/en/insights.json
@@ -4,6 +4,13 @@
   "photos": "photos",
   "noData": "No data available",
   "mostUsed": "Most used",
+  "periods": {
+    "label": "Period:",
+    "all": "All Time",
+    "weekly": "Weekly",
+    "monthly": "Monthly",
+    "yearly": "Yearly"
+  },
   "sections": {
     "shootingTime": "Shooting Time",
     "cameraSettings": "Camera Settings",

--- a/src/i18n/locales/es/insights.json
+++ b/src/i18n/locales/es/insights.json
@@ -4,6 +4,13 @@
   "photos": "fotos",
   "noData": "Sin datos disponibles",
   "mostUsed": "Más usado",
+  "periods": {
+    "label": "Período:",
+    "all": "Todo el tiempo",
+    "weekly": "Semanal",
+    "monthly": "Mensual",
+    "yearly": "Anual"
+  },
   "sections": {
     "shootingTime": "Hora de Disparo",
     "cameraSettings": "Ajustes de Cámara",

--- a/src/i18n/locales/fr/insights.json
+++ b/src/i18n/locales/fr/insights.json
@@ -4,6 +4,13 @@
   "photos": "photos",
   "noData": "Aucune donnée disponible",
   "mostUsed": "Plus utilisé",
+  "periods": {
+    "label": "Période:",
+    "all": "Tout le temps",
+    "weekly": "Hebdomadaire",
+    "monthly": "Mensuel",
+    "yearly": "Annuel"
+  },
   "sections": {
     "shootingTime": "Heure de Prise",
     "cameraSettings": "Réglages Caméra",

--- a/src/i18n/locales/ja/insights.json
+++ b/src/i18n/locales/ja/insights.json
@@ -4,6 +4,13 @@
   "photos": "枚",
   "noData": "データがありません",
   "mostUsed": "最頻値",
+  "periods": {
+    "label": "期間:",
+    "all": "全期間",
+    "weekly": "週間",
+    "monthly": "月間",
+    "yearly": "年間"
+  },
   "sections": {
     "shootingTime": "撮影時間",
     "cameraSettings": "カメラ設定",

--- a/src/i18n/locales/zh-CN/insights.json
+++ b/src/i18n/locales/zh-CN/insights.json
@@ -4,6 +4,13 @@
   "photos": "张照片",
   "noData": "暂无数据",
   "mostUsed": "最常用",
+  "periods": {
+    "label": "时间段:",
+    "all": "全部时间",
+    "weekly": "本周",
+    "monthly": "本月",
+    "yearly": "本年"
+  },
   "sections": {
     "shootingTime": "拍摄时间",
     "cameraSettings": "相机设置",

--- a/src/i18n/locales/zh-TW/insights.json
+++ b/src/i18n/locales/zh-TW/insights.json
@@ -4,6 +4,13 @@
   "photos": "張照片",
   "noData": "暫無資料",
   "mostUsed": "最常用",
+  "periods": {
+    "label": "時間段:",
+    "all": "全部時間",
+    "weekly": "本週",
+    "monthly": "本月",
+    "yearly": "本年"
+  },
   "sections": {
     "shootingTime": "拍攝時間",
     "cameraSettings": "相機設定",

--- a/src/services/InsightsService.js
+++ b/src/services/InsightsService.js
@@ -3,32 +3,45 @@
  *
  * Provides methods for fetching photography statistics and insights.
  * Uses caching and job queue for background calculation.
+ * Supports time period filtering: all, weekly, monthly, yearly.
  */
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { logger } from "./LoggerService.js";
 
+/**
+ * Available time periods for insights filtering
+ */
+export const TIME_PERIODS = {
+    ALL: 'all',
+    WEEKLY: 'weekly',
+    MONTHLY: 'monthly',
+    YEARLY: 'yearly',
+};
+
 const InsightsService = {
     /**
      * Get cached photography insights (fast)
+     * @param {string} period - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
      * @returns {Promise<Object|null>} Cached insights data or null if not available
      */
-    async getCachedInsights() {
-        logger.info('InsightsService', 'get_cached_insights', 'Fetching cached insights');
+    async getCachedInsights(period = TIME_PERIODS.ALL) {
+        logger.info('InsightsService', 'get_cached_insights', 'Fetching cached insights', { period });
         try {
-            const result = await invoke("get_cached_insights");
+            const result = await invoke("get_cached_insights", { period });
             if (result) {
                 const data = JSON.parse(result);
-                logger.info('InsightsService', 'get_cached_insights_success', 'Cached insights found');
+                logger.info('InsightsService', 'get_cached_insights_success', 'Cached insights found', { period });
                 return data;
             }
-            logger.info('InsightsService', 'get_cached_insights_miss', 'No cached insights');
+            logger.info('InsightsService', 'get_cached_insights_miss', 'No cached insights', { period });
             return null;
         } catch (error) {
             const errorMsg = typeof error === 'string' ? error : (error.message || JSON.stringify(error));
             logger.error('InsightsService', 'get_cached_insights_error', 'Failed to get cached insights', {
-                error: errorMsg
+                error: errorMsg,
+                period
             });
             throw new Error(errorMsg);
         }
@@ -36,21 +49,24 @@ const InsightsService = {
 
     /**
      * Get cache status (whether cache exists and how old it is)
+     * @param {string} period - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
      * @returns {Promise<Object>} Cache status with available, age_secs, path
      */
-    async getCacheStatus() {
-        logger.info('InsightsService', 'get_cache_status', 'Checking cache status');
+    async getCacheStatus(period = TIME_PERIODS.ALL) {
+        logger.info('InsightsService', 'get_cache_status', 'Checking cache status', { period });
         try {
-            const result = await invoke("get_insights_cache_status");
+            const result = await invoke("get_insights_cache_status", { period });
             logger.info('InsightsService', 'get_cache_status_success', 'Cache status retrieved', {
                 available: result.available,
-                age_secs: result.age_secs
+                age_secs: result.age_secs,
+                period
             });
             return result;
         } catch (error) {
             const errorMsg = typeof error === 'string' ? error : (error.message || JSON.stringify(error));
             logger.error('InsightsService', 'get_cache_status_error', 'Failed to get cache status', {
-                error: errorMsg
+                error: errorMsg,
+                period
             });
             throw new Error(errorMsg);
         }
@@ -58,20 +74,23 @@ const InsightsService = {
 
     /**
      * Queue insights refresh job
+     * @param {string} period - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
      * @returns {Promise<string>} Job unit ID for tracking
      */
-    async queueRefresh() {
-        logger.info('InsightsService', 'queue_refresh', 'Queueing insights refresh');
+    async queueRefresh(period = TIME_PERIODS.ALL) {
+        logger.info('InsightsService', 'queue_refresh', 'Queueing insights refresh', { period });
         try {
-            const jobUnitId = await invoke("queue_insights_refresh");
+            const jobUnitId = await invoke("queue_insights_refresh", { period });
             logger.info('InsightsService', 'queue_refresh_success', 'Refresh job queued', {
-                jobUnitId
+                jobUnitId,
+                period
             });
             return jobUnitId;
         } catch (error) {
             const errorMsg = typeof error === 'string' ? error : (error.message || JSON.stringify(error));
             logger.error('InsightsService', 'queue_refresh_error', 'Failed to queue refresh', {
-                error: errorMsg
+                error: errorMsg,
+                period
             });
             throw new Error(errorMsg);
         }
@@ -79,7 +98,7 @@ const InsightsService = {
 
     /**
      * Listen for insights update events
-     * @param {Function} callback - Called when insights are updated
+     * @param {Function} callback - Called when insights are updated (receives { path, period })
      * @returns {Promise<Function>} Unlisten function
      */
     async onInsightsUpdated(callback) {
@@ -94,22 +113,25 @@ const InsightsService = {
     /**
      * Get photography insights directly (may be slow, fallback)
      * Prefer using getCachedInsights + queueRefresh
+     * @param {string} period - Time period: "all", "weekly", "monthly", "yearly" (default: "all")
      * @returns {Promise<Object>} Photography insights data
      */
-    async getInsights() {
-        logger.info('InsightsService', 'get_insights', 'Fetching photography insights directly');
+    async getInsights(period = TIME_PERIODS.ALL) {
+        logger.info('InsightsService', 'get_insights', 'Fetching photography insights directly', { period });
         try {
-            const result = await invoke("get_photography_insights");
+            const result = await invoke("get_photography_insights", { period });
             const data = JSON.parse(result);
             logger.info('InsightsService', 'get_insights_success', 'Insights loaded', {
-                totalPhotos: data.organization?.total_photos
+                totalPhotos: data.organization?.total_photos,
+                period
             });
             return data;
         } catch (error) {
             const errorMsg = typeof error === 'string' ? error : (error.message || JSON.stringify(error));
             logger.error('InsightsService', 'get_insights_error', 'Failed to fetch insights', {
                 error: errorMsg,
-                rawError: error
+                rawError: error,
+                period
             });
             throw new Error(errorMsg);
         }

--- a/src/utils/ShareUtils.js
+++ b/src/utils/ShareUtils.js
@@ -9,7 +9,7 @@ import { logger } from '../services/LoggerService.js';
 /**
  * Generate share text from insights data
  * @param {Object} insights - Insights data from InsightsService
- * @param {string} period - 'all' | 'monthly' | 'yearly'
+ * @param {string} period - 'all' | 'weekly' | 'monthly' | 'yearly'
  * @returns {string} Formatted share text
  */
 export function generateStatsShareText(insights, period = 'all') {
@@ -19,7 +19,9 @@ export function generateStatsShareText(insights, period = 'all') {
     const now = new Date();
 
     // Header based on period
-    if (period === 'monthly') {
+    if (period === 'weekly') {
+        lines.push('📊 This Week\'s Photography Stats');
+    } else if (period === 'monthly') {
         const monthName = now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
         lines.push(`📊 ${monthName} Photography Stats`);
     } else if (period === 'yearly') {
@@ -201,7 +203,8 @@ export async function generateStatsImage(insights, options = {}) {
         height = 400,
         backgroundColor = '#1a1a2e',
         textColor = '#ffffff',
-        accentColor = '#4ade80'
+        accentColor = '#4ade80',
+        period = 'all'
     } = options;
 
     const canvas = document.createElement('canvas');
@@ -218,10 +221,21 @@ export async function generateStatsImage(insights, options = {}) {
     ctx.lineWidth = 2;
     ctx.strokeRect(1, 1, width - 2, height - 2);
 
-    // Header
+    // Header based on period
+    let headerText = '📊 Photography Stats';
+    const now = new Date();
+    if (period === 'weekly') {
+        headerText = '📊 This Week\'s Stats';
+    } else if (period === 'monthly') {
+        const monthName = now.toLocaleDateString('en-US', { month: 'long' });
+        headerText = `📊 ${monthName} Stats`;
+    } else if (period === 'yearly') {
+        headerText = `📊 ${now.getFullYear()} Stats`;
+    }
+
     ctx.fillStyle = textColor;
     ctx.font = 'bold 28px -apple-system, BlinkMacSystemFont, sans-serif';
-    ctx.fillText('📊 Photography Stats', 30, 50);
+    ctx.fillText(headerText, 30, 50);
 
     // Stats
     let y = 100;


### PR DESCRIPTION
## Summary
This PR adds support for time period filtering to the photography insights feature, allowing users to view statistics for "All Time", "Weekly", "Monthly", or "Yearly" periods. Each period has its own cached insights file and separate database queries with date filtering.

## Key Changes

### Backend (Rust)
- **New `TimePeriod` enum** in `stats.rs` with variants: `All`, `Weekly`, `Monthly`, `Yearly`
  - Implements `start_date()` to calculate the cutoff date for each period
  - Provides `date_condition()` to generate SQL WHERE clauses for filtering
  - Includes `from_str()` and `as_str()` for serialization/deserialization

- **Updated all stats commands** to accept optional `period` parameter:
  - `get_cached_insights(period)`
  - `get_insights_cache_status(period)`
  - `queue_insights_refresh(period)`
  - `get_photography_insights(period)`

- **Period-specific caching**: Cache files are now named `insights_{period}.json` instead of a single `insights.json`

- **Date filtering in SQL queries**: All statistics queries (shooting time, camera settings, equipment, organization) now include date conditions based on the selected period
  - Storage stats remain unfiltered (always show current usage)
  - Tags and albums counts are not filtered by date (they're collections, not photos)

- **Job queue integration**: Period is passed to the job handler via the job's `targets` field, and the `insights_updated` event now includes period information

### Frontend (React/JavaScript)
- **Period selector UI** in `InsightsModal.jsx`:
  - Four buttons for period selection (All Time, Weekly, Monthly, Yearly)
  - Positioned above the existing section tabs
  - Disabled during loading/refreshing

- **Period state management**: 
  - Tracks selected period and reloads insights when period changes
  - Only updates UI when the received event matches the currently selected period

- **Updated `InsightsService`**:
  - All methods now accept optional `period` parameter
  - Event listener receives payload with period information

- **Internationalization**: Added period labels to all supported languages (EN, DE, ES, FR, JA, ZH-CN, ZH-TW)

## Implementation Details
- Date filtering uses `COALESCE(exif_date_time_original, photo_date)` to handle both EXIF and fallback dates
- Weekly = last 7 days, Monthly = last 30 days, Yearly = last 365 days
- Separate cache files prevent cache invalidation when switching periods
- Logging includes period information for debugging
- Storage stats are intentionally excluded from date filtering as they represent current disk usage

https://claude.ai/code/session_01LrptEkGcJrE6RmZdQimjxY