### PR TITLE
Simplify video streaming to use asset protocol instead of HTTP server

### DIFF
--- a/src/App/PhotosList/PhotosListMini/PhotoDisplay.jsx
+++ b/src/App/PhotosList/PhotosListMini/PhotoDisplay.jsx
@@ -350,40 +350,15 @@ function PhotoDisplay(props) {
         };
     }, [props.currentDisplayPath, props.thumbnailSrc, props.imgCacheMap, props.progressiveImageLoading]);
 
-    async function movie(path) {
-        if (currentFile != path) {
-            try {
-                // Use optimized HTTP streaming server
-                logger.info('PhotoDisplay', 'video_streaming_init', 'Starting optimized video streaming');
-                const serverUrl = await invoke("start_video_server");
-                
-                // Register video path and get streaming URL
-                const streamingUrl = await invoke("register_video_path", { 
-                    videoPath: path 
-                });
-                
-                currentFile = path;
-                setVideoSource(streamingUrl);
-                
-                logger.info('PhotoDisplay', 'video_streaming_success', 'Optimized streaming started', { 
-                    path, 
-                    streamingUrl,
-                    protocol: 'http_optimized' 
-                });
-                
-            } catch (error) {
-                logger.error('PhotoDisplay', 'video_streaming_error', 'Streaming failed', { 
-                    path, 
-                    error: error.toString()
-                });
-                
-                // Fallback to external player
-                await openUrl(fileUrl(path));
-                setVideoSource("");
-                return false;
-            }
+    function movie(path) {
+        if (currentFile !== path) {
+            currentFile = path;
+            // Use asset protocol which is allowed by CSP (media-src includes asset:)
+            // The warp HTTP server was blocked by mixed-content policy (HTTPS page → HTTP server)
+            const assetUrl = convertFileSrc(path);
+            setVideoSource(assetUrl);
+            logger.info('PhotoDisplay', 'video_load', 'Loading video via asset protocol', { path, assetUrl });
         }
-        return true;
     }
 
     const handleImgLoad = (e, retryCount = 0) => {


### PR DESCRIPTION
## Summary
Refactored the video streaming implementation to use Tauri's asset protocol (`convertFileSrc`) instead of a custom HTTP streaming server. This resolves mixed-content policy issues and simplifies the video loading logic.

## Key Changes
- Removed async HTTP streaming server initialization and video path registration logic
- Replaced with synchronous asset protocol conversion using `convertFileSrc()`
- Simplified error handling by removing fallback to external player
- Changed comparison operator from `!=` to `!==` for consistency
- Removed return value from `movie()` function (was returning boolean)
- Updated logging to reflect the new asset-based approach

## Implementation Details
- The asset protocol is already allowed by the Content Security Policy (CSP) with `media-src 'asset:'`
- The previous HTTP server approach was blocked by mixed-content policy when running on HTTPS pages
- The new approach is simpler and more direct, converting file paths to asset URLs that can be loaded directly by the video player

https://claude.ai/code/session_01PAng7b9VPTsgQMeKVRMkFZ